### PR TITLE
editable property-attributes

### DIFF
--- a/components/input.html
+++ b/components/input.html
@@ -17,6 +17,26 @@
         setValue: function (val) {
           this.querySelector('input[type="text"]').value = val.toString();
         }
+      },
+      editable: {
+        "defaulttext": {
+          label: "Placeholder text",
+          type: "text",
+          description: "The text you want your input field to show by default.",
+          edit: function(v) {
+            console.log("setting " + v);
+            this.querySelector("input").setAttribute("placeholder", v);
+          }
+        },
+        "buttontext": {
+          label: "Button label",
+          type: "text",
+          description: "The text label you want your button to have.",
+          edit: function(v) {
+            console.log("setting " + v);
+            this.querySelector("button").innerHTML = v;
+          }
+        }
       }
     });
   </script>

--- a/components/input.html
+++ b/components/input.html
@@ -24,7 +24,6 @@
           type: "text",
           description: "The text you want your input field to show by default.",
           edit: function(v) {
-            console.log("setting " + v);
             this.querySelector("input").setAttribute("placeholder", v);
           }
         },
@@ -33,7 +32,6 @@
           type: "text",
           description: "The text label you want your button to have.",
           edit: function(v) {
-            console.log("setting " + v);
             this.querySelector("button").innerHTML = v;
           }
         }


### PR DESCRIPTION
Run ceci's index.html and in the console type `$("#input").buttontext = "new text"`. Magic - the button innerHTML changes, _and_ the <app-input> element now has an attribute called `buttontext` with that same string. Changing the attribute by hand will also change the button's innerHTML. `defaulttext` has a similar handling.

To get the definition for UI work: `$("input").getAttributeDefinition("buttontext")` or `$("input").getAttributeDefinition("defaulttext")`.
