### PR TITLE
Make inputs and submit form work together to create compound forms

### DIFF
--- a/assets/style/app-button.css
+++ b/assets/style/app-button.css
@@ -1,7 +1,7 @@
 @import url("../fonts.css");
 
 app-button {
-  padding: 0 1.5rem;
+  padding: 0;
 }
 
 app-button .button:active {

--- a/assets/style/app-input.css
+++ b/assets/style/app-input.css
@@ -29,6 +29,10 @@ app-input input[type=text]{
   font-family: "FiraSans", sans-serif;
 }
 
+app-input.onchange input[type=text]{
+  width: 100%;
+}
+
 app-input button {
   background: -moz-linear-gradient(top, #f8f8f8, #ddd);
   background: -webkit-linear-gradient(top, #f8f8f8, #ddd);

--- a/assets/style/app-input.css
+++ b/assets/style/app-input.css
@@ -1,7 +1,7 @@
 @import url("../fonts.css");
 
 app-input {
-  padding: 0 1.5rem;
+  padding: 0;
   height: 3.8rem;
 }  
 

--- a/assets/style/app-submit.css
+++ b/assets/style/app-submit.css
@@ -4,12 +4,12 @@ app-submit {
   padding: 0 1.5rem;
 }
 
-app-submit #button:active {
+app-submit .button:active {
   background: -moz-linear-gradient(top, #ddd, #ddd);
   background: -webkit-linear-gradient(top, #ddd, #ddd);
 }
 
-app-submit #button {
+app-submit .button {
   padding: 0 1.5rem;
   position: relative;
   text-decoration: none;

--- a/assets/style/app-submit.css
+++ b/assets/style/app-submit.css
@@ -1,7 +1,7 @@
 @import url("../fonts.css");
 
 app-submit {
-  padding: 0 1.5rem;
+  padding: 0;
 }
 
 app-submit .button:active {

--- a/assets/style/app-submit.css
+++ b/assets/style/app-submit.css
@@ -1,0 +1,40 @@
+@import url("../fonts.css");
+
+app-submit {
+  padding: 0 1.5rem;
+}
+
+app-submit #button:active {
+  background: -moz-linear-gradient(top, #ddd, #ddd);
+  background: -webkit-linear-gradient(top, #ddd, #ddd);
+}
+
+app-submit #button {
+  padding: 0 1.5rem;
+  position: relative;
+  text-decoration: none;
+  outline: none;
+  background: -moz-linear-gradient(top, #f8f8f8, #ddd);
+  background: -webkit-linear-gradient(top, #f8f8f8, #ddd);
+  text-align: center;
+  text-shadow: 0.1rem 0.1rem 0 rgba(255, 255, 255, 0.3);
+  display: block;
+  vertical-align: middle;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  border: 0.1rem solid #a6a6a6;
+  border-radius: 0.2rem;
+  font-weight: 500;
+  font-size: 1.6rem;
+  line-height: 3.8rem;
+  color: #333;
+}
+
+app-submit button {
+  font-family: "FiraSans", sans-serif;
+  border: none;
+  background: 0;
+  font-weight: 500;
+  font-size: 1.6rem;
+  position: relative;
+}

--- a/components/input.html
+++ b/components/input.html
@@ -9,25 +9,24 @@
   <script type="text/ceci">
     Ceci(this, {
       init: function (params) {
-        this.querySelector('input[type="text"]')
-          .setAttribute('placeholder', 'Placeholder Text');
-        // this.setAttribute('fireonchange', false);
+        this.input = this.querySelector('input');
+        this.input.setAttribute('placeholder', 'Placeholder Text');
 
         var that = this;
         this.button = this.querySelector('button');
         this.button.onclick = function (e) {
+          console.log('got onclick', that._fireonchange);
           var input = that.querySelector('input[type="text"]');
           that.broadcast(input.value);
           input.value = "";
         };
-        this.button.onchange = function (e) {
-          console.log('got onchange', that._fireonchange);
+        this.input.addEventListener("input", function (e) {
+          console.log('got onchange');
           if (! that._fireonchange) return;
-          var input = that.querySelector('input[type="text"]');
-          that.broadcast(input.value);
-          input.value = "";
-        };
-        
+          that.broadcast(that.input.value);
+        }, false);
+
+        this.setAttribute("fireonchange", false);
         this.setAttribute("placeholdertext","Placeholder");
         this.setAttribute("buttontext","OK");        
       },
@@ -72,7 +71,6 @@
           type: "boolean",
           description: "Emit on change",
           postset: function(v) {
-            console.log(v);
             this._fireonchange = v == "true" ? true : false;
             this.updateConfig();
           }

--- a/components/input.html
+++ b/components/input.html
@@ -9,10 +9,20 @@
   <script type="text/ceci">
     Ceci(this, {
       init: function (params) {
+        this.querySelector('input[type="text"]')
+          .setAttribute('placeholder', 'Placeholder Text');
+        // this.setAttribute('fireonchange', false);
 
         var that = this;
-        
-        this.querySelector('button').onclick = function (e) {
+        this.button = this.querySelector('button');
+        this.button.onclick = function (e) {
+          var input = that.querySelector('input[type="text"]');
+          that.broadcast(input.value);
+          input.value = "";
+        };
+        this.button.onchange = function (e) {
+          console.log('got onchange', that._fireonchange);
+          if (! that._fireonchange) return;
           var input = that.querySelector('input[type="text"]');
           that.broadcast(input.value);
           input.value = "";
@@ -28,6 +38,15 @@
       },
       broadcast: function (e) {
         this.emit(e)
+      },
+      updateConfig: function() {
+        if (this._fireonchange) {
+          this.classList.add('onchange');
+          this.button.classList.add('hidden');
+        } else {
+          this.classList.remove('onchange');
+          this.button.classList.remove('hidden');
+        }
       },
       editable: {
         "placeholdertext": {
@@ -46,6 +65,16 @@
           description: "The text label you want your button to have.",
           postset: function(v) {
             this.querySelector("button").innerHTML = v;
+          }
+        },
+        "fireonchange": {
+          title: "Emit on change",
+          type: "boolean",
+          description: "Emit on change",
+          postset: function(v) {
+            console.log(v);
+            this._fireonchange = v == "true" ? true : false;
+            this.updateConfig();
           }
         }
       }

--- a/components/input.html
+++ b/components/input.html
@@ -1,9 +1,7 @@
 <element name="app-input">
   <template>
     <link rel="stylesheet" href="{{ASSET_HOST}}/assets/style/app-input.css">
-    <div>
-      <input type="text"/><button>Submit</button>
-    </div>
+    <input type="text"/><button>Submit</button>
   </template>
   <description>
     I broadcast whatever message a user types.

--- a/components/input.html
+++ b/components/input.html
@@ -1,7 +1,9 @@
 <element name="app-input">
   <template>
     <link rel="stylesheet" href="{{ASSET_HOST}}/assets/style/app-input.css">
-    <input type="text"><button>Submit</button>
+    <div>
+      <input type="text"/><button>Submit</button>
+    </div>
   </template>
   <description>
     I broadcast whatever message a user types.

--- a/components/map.html
+++ b/components/map.html
@@ -94,6 +94,9 @@
           recordLocation: function(val) {
             this.broadcast(this.map.getCenter());
           },
+          centerOnLocation: function(location) {
+            this.map.panTo({'lat':Number(location.lat), 'lon':Number(location.lon)});
+          },
           centerOnPhone: function(val) {
             this.map.locate({setView: true, maxZoom: 16});
           },

--- a/components/submit.html
+++ b/components/submit.html
@@ -18,19 +18,12 @@
         var t = this;
         this._data = {};
         button.onclick = function (e) {
-          console.log("GOT CLICK");
-          try {
-            var packet = {};
-            packet[t.getAttribute('a')] = t._data['a'];
-            packet[t.getAttribute('b')] = t._data['b'];
-            packet[t.getAttribute('c')] = t._data['c'];
-            packet[t.getAttribute('d')] = t._data['d'];
-            console.log(packet)
-            t.broadcast(JSON.stringify(packet));
-            return true;
-          } catch (e) {
-            console.log(e);
-          }
+          var packet = {};
+          packet[t.getAttribute('a')] = t._data['a'];
+          packet[t.getAttribute('b')] = t._data['b'];
+          packet[t.getAttribute('c')] = t._data['c'];
+          packet[t.getAttribute('d')] = t._data['d'];
+          t.broadcast(JSON.stringify(packet));
         };
         this.setAttribute("a", "foo");
         this.setAttribute("b", "bar");
@@ -43,10 +36,7 @@
           label: "Slot A will receive:",
           type: "text",
           description: "aa",
-          postset: function(v) {
-            console.log('postset', v);
-            // this._A = v;
-          }
+          postset: function(v) { }
         },
         "b": {
           type: "text",

--- a/components/submit.html
+++ b/components/submit.html
@@ -28,10 +28,18 @@
           packet[t.getAttribute('d')] = t._data['d'];
           t.broadcast(packet);
         };
-        this.setAttribute("a", "foo");
-        this.setAttribute("b", "bar");
-        this.setAttribute("c", "baz");
-        this.setAttribute("d", "bam");
+        if (! this.hasAttribute('a')) {
+          this.setAttribute("a", "foo");
+        }
+        if (! this.hasAttribute('b')) {
+          this.setAttribute("b", "bar");
+        }
+        if (! this.hasAttribute('c')) {
+          this.setAttribute("c", "baz");
+        }
+        if (! this.hasAttribute('d')) {
+          this.setAttribute("d", "bam");
+        }
       },
       editable: {
         "label": {

--- a/components/submit.html
+++ b/components/submit.html
@@ -1,0 +1,92 @@
+<element name="app-submit">
+  <template>
+    <link rel="stylesheet" href="{{ASSET_HOST}}/assets/style/app-submit.css"></link>
+    <style type="text/css">
+    </style>
+    <div id="button">
+      <button>Submit</button>
+    </div>
+  </div>
+  </template>
+  <description>
+    When clicked I broadcast an aggregate of all my inputs
+  </description>
+  <script type="text/ceci">
+    Ceci(this, {
+      init: function (params) {
+        var button = this.querySelector('button')
+        var t = this;
+        this._data = {};
+        button.onclick = function (e) {
+          console.log("GOT CLICK");
+          try {
+            var packet = {};
+            packet[t.getAttribute('a')] = t._data['a'];
+            packet[t.getAttribute('b')] = t._data['b'];
+            packet[t.getAttribute('c')] = t._data['c'];
+            packet[t.getAttribute('d')] = t._data['d'];
+            console.log(packet)
+            t.broadcast(JSON.stringify(packet));
+            return true;
+          } catch (e) {
+            console.log(e);
+          }
+        };
+        this.setAttribute("a", "foo");
+        this.setAttribute("b", "bar");
+        this.setAttribute("c", "baz");
+        this.setAttribute("d", "bam");
+      },
+      editable: {
+        "a": {
+          title: "Slot A will receive:",
+          label: "Slot A will receive:",
+          type: "text",
+          description: "aa",
+          postset: function(v) {
+            console.log('postset', v);
+            // this._A = v;
+          }
+        },
+        "b": {
+          type: "text",
+          title: "Slot B will receive:",
+          label: "Slot B will receive:",
+          description: "jh",
+          postset: function(v) { }
+        },
+        "c": {
+          type: "text",
+          title: "Slot C will receive:",
+          label: "Slot C will receive:",
+          description: "lkj",
+          postset: function(v) { }
+        },
+        "d": {
+          type: "text",
+          title: "Slot D will receive:",
+          label: "Slot D will receive:",
+          description: "kjh",
+          postset: function(v) { }
+        },
+      },
+      listeners: {
+        setSlotA: function (val) {
+          this._data['a'] = val;
+        },
+        setSlotB: function (val) {
+          this._data['b'] = val;
+        },
+        setSlotC: function (val) {
+          this._data['c'] = val;
+        },
+        setSlotD: function (val) {
+          this._data['d'] = val;
+        },
+      },
+      broadcast: function (e) {
+        this.emit(e)
+      }
+    });
+  </script>
+</element>

--- a/components/submit.html
+++ b/components/submit.html
@@ -3,8 +3,10 @@
     <link rel="stylesheet" href="{{ASSET_HOST}}/assets/style/app-submit.css"></link>
     <style type="text/css">
     </style>
-    <div id="button">
-      <button>Submit</button>
+    <div>
+      <div class='button'>
+        <button>Submit</button>
+      </div>
     </div>
   </div>
   </template>
@@ -17,13 +19,14 @@
         var button = this.querySelector('button')
         var t = this;
         this._data = {};
+        this.setAttribute('label', 'Submit');
         button.onclick = function (e) {
           var packet = {};
           packet[t.getAttribute('a')] = t._data['a'];
           packet[t.getAttribute('b')] = t._data['b'];
           packet[t.getAttribute('c')] = t._data['c'];
           packet[t.getAttribute('d')] = t._data['d'];
-          t.broadcast(JSON.stringify(packet));
+          t.broadcast(packet);
         };
         this.setAttribute("a", "foo");
         this.setAttribute("b", "bar");
@@ -31,6 +34,15 @@
         this.setAttribute("d", "bam");
       },
       editable: {
+        "label": {
+          title: "Button Label",
+          label: "Button Label:",
+          type: "text",
+          description: "aa",
+          postset: function(val) {
+            this.querySelector('button').innerHTML = val;
+          }
+        },
         "a": {
           title: "Slot A will receive:",
           label: "Slot A will receive:",


### PR DESCRIPTION
By adding a toggle to input components, it's now possible to have up to 4 input forms send their data on data change (not on submit click) to a submit button, which aggregates them and sends them (currently as a JSON string) on hitting a submit button.  The submit button has attributes which determine the keys to be used in the k-v struct.

e.g.
input(defaultText=Name) -> submit.slotA
input(defaultText=Phone) -> submit.slotB

submit.slotA = "name"
submit.slotB = "phone"

then if you type 'david' in the first input and 123 in the second, and hit submit, submit will emit {'name': 'David', 'phone': 123} (e.g. to be processed by a data-list)

I think I'll get rid of the JSONificiation after I play with it e.g. w/ the map widget (e.g. specify Lat & Long), but wanted to share early & often.
